### PR TITLE
Adding Enemy line of sight, closing #20

### DIFF
--- a/game/__main__.py
+++ b/game/__main__.py
@@ -177,7 +177,7 @@ def main():
 
     game_view = GameView(main_window)
     game_view.setup()
-    arcade.schedule(game_view.enemy_moving, 1 / 8)
+    arcade.schedule(game_view.enemy_moving, 1 / 20)
 
     main_window.show_view(game_view)
 

--- a/game/__main__.py
+++ b/game/__main__.py
@@ -1,5 +1,6 @@
 from typing import Optional
 import time
+from enum import Enum
 
 import utils
 
@@ -17,6 +18,10 @@ from ingame_ui import IngameUI
 
 from music_player import MusicPlayer
 
+class GameState(Enum):
+    playermove = 1
+    enemymove = 2
+    enemyturning = 3
 
 class GameView(arcade.View):
     def __init__(self, window):
@@ -30,7 +35,7 @@ class GameView(arcade.View):
 
         self.music_player = MusicPlayer()
 
-        self.gamestate = "playersturn"
+        self.gamestate = GameState.playermove
 
     def setup(self):
         self.load_map()
@@ -93,7 +98,7 @@ class GameView(arcade.View):
         )
 
     def on_key_press(self, key: int, modifiers: int):
-        if self.gamestate != "playersturn":
+        if self.gamestate != GameState.playermove:
             return
         if key in [arcade.key.UP, arcade.key.LEFT, arcade.key.RIGHT, arcade.key.DOWN]:
             # Record Original Pos so if collision with wall is detected, we return the
@@ -107,22 +112,22 @@ class GameView(arcade.View):
 
             self.set_viewport_on_player()
             self._draw()
-            self.gamestate = "enemymove"
+            self.gamestate = GameState.enemymove
 
     def enemy_moving(self, delta_time):
-        if self.gamestate == "enemymove":
+        if self.gamestate == GameState.enemymove:
             for enemy in self.enemy_list:
                 enemy.move_one()
             self._draw()
-            self.gamestate = "enemyturning"
-        elif self.gamestate == "enemyturning":
+            self.gamestate = GameState.enemyturning
+        elif self.gamestate == GameState.enemyturning:
             for enemy in self.enemy_list:
                 enemy.update_direction()
             self._draw()
             if any(enemy.movesleft for enemy in self.enemy_list):
-                self.gamestate = "enemymove"
+                self.gamestate = GameState.enemymove
             else:
-                self.gamestate = "playersturn"
+                self.gamestate = GameState.playermove
 
     def set_viewport_on_player(self):
         """

--- a/game/__main__.py
+++ b/game/__main__.py
@@ -1,4 +1,5 @@
 from typing import Optional
+import time
 
 import utils
 
@@ -28,6 +29,8 @@ class GameView(arcade.View):
         self.ingame_ui: Optional[IngameUI] = None
 
         self.music_player = MusicPlayer()
+
+        self.gamestate = "playersturn"
 
     def setup(self):
         self.load_map()
@@ -90,6 +93,8 @@ class GameView(arcade.View):
         )
 
     def on_key_press(self, key: int, modifiers: int):
+        if self.gamestate != "playersturn":
+            return
         if key in [arcade.key.UP, arcade.key.LEFT, arcade.key.RIGHT, arcade.key.DOWN]:
             # Record Original Pos so if collision with wall is detected, we return the
             # player to that spot before rendering, making it impassable.
@@ -102,6 +107,22 @@ class GameView(arcade.View):
 
             self.set_viewport_on_player()
             self._draw()
+            self.gamestate = "enemymove"
+
+    def enemy_moving(self, delta_time):
+        if self.gamestate == "enemymove":
+            for enemy in self.enemy_list:
+                enemy.move_one()
+            self._draw()
+            self.gamestate = "enemyturning"
+        elif self.gamestate == "enemyturning":
+            for enemy in self.enemy_list:
+                enemy.update_direction()
+            self._draw()
+            if any(enemy.movesleft for enemy in self.enemy_list):
+                self.gamestate = "enemymove"
+            else:
+                self.gamestate = "playersturn"
 
     def set_viewport_on_player(self):
         """
@@ -110,10 +131,12 @@ class GameView(arcade.View):
         :return:
         """
         clamped_x = min(
-            SCREEN_WIDTH, max(0, self.player.center_x - HORIZONTAL_VIEWPORT_MARGIN),
+            SCREEN_WIDTH,
+            max(0, self.player.center_x - HORIZONTAL_VIEWPORT_MARGIN),
         )
         clamped_y = min(
-            SCREEN_HEIGHT, max(0, self.player.center_y - VERTICAL_VIEWPORT_MARGIN),
+            SCREEN_HEIGHT,
+            max(0, self.player.center_y - VERTICAL_VIEWPORT_MARGIN),
         )
         arcade.set_viewport(
             clamped_x, SCREEN_WIDTH + clamped_x, clamped_y, SCREEN_HEIGHT + clamped_y
@@ -140,6 +163,7 @@ class GameView(arcade.View):
         self.enemy_list.draw(filter=GL_NEAREST)
         for enemy in self.enemy_list:
             enemy.draw_path()
+            enemy.draw_vision()
         self.player.draw()
 
     def on_draw(self):
@@ -153,6 +177,7 @@ def main():
 
     game_view = GameView(main_window)
     game_view.setup()
+    arcade.schedule(game_view.enemy_moving, 1 / 8)
 
     main_window.show_view(game_view)
 

--- a/game/assets/tilemaps/TestLevel.tmx
+++ b/game/assets/tilemaps/TestLevel.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.5.0" orientation="orthogonal" renderorder="right-down" width="60" height="30" tilewidth="8" tileheight="8" infinite="0" nextlayerid="6" nextobjectid="28">
+<map version="1.5" tiledversion="1.5.0" orientation="orthogonal" renderorder="right-down" width="60" height="30" tilewidth="8" tileheight="8" infinite="0" nextlayerid="11" nextobjectid="46">
  <tileset firstgid="1" source="jawbreaker_tiles.tsx"/>
  <layer id="1" name="walls" width="60" height="30">
   <data encoding="csv">
@@ -9,7 +9,7 @@
 26,0,0,0,0,0,0,0,0,26,0,0,0,0,0,26,0,0,0,0,26,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,26,
 26,0,41,41,41,20,41,0,60,26,0,0,0,0,0,26,0,0,0,0,26,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,26,
 26,0,0,0,0,26,0,0,0,26,0,0,0,0,0,26,0,0,0,0,26,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,26,
-26,0,0,0,0,26,0,0,0,26,0,0,0,0,0,26,0,0,0,0,26,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,26,
+26,0,0,0,0,26,0,0,0,26,0,0,0,0,0,0,0,0,0,0,26,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,26,
 26,0,0,0,0,26,0,0,0,26,0,0,0,0,0,26,0,0,0,0,26,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,26,
 26,0,0,0,0,26,0,0,0,26,0,0,0,0,0,26,0,0,0,0,26,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,26,
 26,0,0,0,0,28,41,41,41,36,41,41,41,0,41,26,0,0,0,0,26,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,26,
@@ -43,7 +43,7 @@
 0,27,12,12,12,12,12,12,12,0,27,12,12,12,12,0,27,12,12,12,0,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,0,
 0,27,0,0,0,0,0,12,0,0,27,12,12,12,12,0,27,12,12,12,0,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,0,
 0,27,12,12,12,0,3,12,68,0,27,12,12,12,12,0,27,12,12,12,0,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,0,
-0,27,12,12,12,0,27,12,12,0,27,12,12,12,12,0,27,12,12,12,0,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,0,
+0,27,12,12,12,0,27,12,12,0,27,12,12,12,12,12,27,12,12,12,0,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,0,
 0,27,12,12,12,0,27,12,12,0,27,12,12,12,12,0,27,12,12,12,0,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,0,
 0,27,12,12,12,0,27,12,12,0,27,12,12,12,12,0,27,12,12,12,0,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,0,
 0,27,12,12,12,0,0,0,0,0,0,0,0,27,0,0,27,12,12,12,0,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,0,
@@ -69,25 +69,63 @@
 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 </data>
  </layer>
- <objectgroup color="#0000c8" id="4" name="guard1">
+ <objectgroup id="4" name="guard1">
   <properties>
    <property name="type" value="guard"/>
   </properties>
-  <object id="18" name="1" type="point" x="136" y="192" width="8" height="8"/>
-  <object id="19" name="spawn" type="spawn" x="144" y="64" width="8" height="8"/>
-  <object id="22" name="0" type="point" x="136" y="88" width="8" height="8"/>
- </objectgroup>
- <objectgroup color="#0000c8" id="5" name="guard2">
-  <object id="24" name="1" type="point" x="216" y="120" width="8" height="8"/>
-  <object id="25" name="spawn" type="spawn" x="184" y="40" width="8" height="8"/>
-  <object id="26" name="0" type="point" x="200" y="48" width="8" height="8"/>
+  <object id="22" name="0" type="point" x="192" y="104" width="8" height="8"/>
+  <object id="23" name="spawn" type="spawn" x="128" y="104" width="8" height="8"/>
  </objectgroup>
  <objectgroup id="5" name="guard2">
   <properties>
    <property name="type" value="guard"/>
   </properties>
-  <object id="23" name="0" type="point" x="80" y="104" width="8" height="8"/>
-  <object id="24" name="spawn" type="spawn" x="104" y="72" width="8" height="8"/>
+  <object id="24" name="2" type="point" x="216" y="120" width="8" height="8"/>
+  <object id="25" name="spawn" type="spawn" x="176.25" y="16.25" width="8" height="8"/>
+  <object id="26" name="0" type="point" x="263.5" y="15.5" width="8" height="8"/>
+  <object id="28" name="1" type="point" x="264" y="120" width="8" height="8"/>
+  <object id="29" name="4" type="point" x="176" y="72" width="8" height="8"/>
+  <object id="30" name="3" type="point" x="216" y="72" width="8" height="8"/>
+ </objectgroup>
+ <objectgroup id="6" name="guard3">
+  <properties>
+   <property name="type" value="guard"/>
+  </properties>
+  <object id="31" name="0" type="point" x="192" y="112" width="8" height="8"/>
+  <object id="32" name="spawn" type="spawn" x="136" y="112" width="8" height="8"/>
+  <object id="33" name="1" type="point" x="128" y="112" width="8" height="8"/>
+ </objectgroup>
+ <objectgroup id="7" name="guard4">
+  <properties>
+   <property name="type" value="guard"/>
+  </properties>
+  <object id="34" name="0" type="point" x="192" y="120" width="8" height="8"/>
+  <object id="35" name="spawn" type="spawn" x="144" y="120" width="8" height="8"/>
+  <object id="36" name="1" type="point" x="128" y="120" width="8" height="8"/>
+ </objectgroup>
+ <objectgroup id="8" name="guard5">
+  <properties>
+   <property name="type" value="guard"/>
+  </properties>
+  <object id="37" name="0" type="point" x="112" y="88" width="8" height="8"/>
+  <object id="38" name="spawn" type="spawn" x="56" y="88" width="8" height="8"/>
+  <object id="39" name="1" type="point" x="48" y="88" width="8" height="8"/>
+ </objectgroup>
+ <objectgroup id="9" name="guard6">
+  <properties>
+   <property name="type" value="guard"/>
+  </properties>
+  <object id="40" name="0" type="point" x="112" y="96" width="8" height="8"/>
+  <object id="41" name="spawn" type="spawn" x="72" y="96" width="8" height="8"/>
+  <object id="42" name="1" type="point" x="48" y="96" width="8" height="8"/>
+ </objectgroup>
+ <objectgroup id="10" name="guard7">
+  <properties>
+   <property name="type" value="guard"/>
+  </properties>
+  <object id="43" name="0" type="point" x="112" y="104" width="8" height="8"/>
+  <object id="44" name="spawn" type="spawn" x="96" y="104" width="8" height="8"/>
+  <object id="45" name="1" type="point" x="48" y="104" width="8" height="8"/>
  </objectgroup>
  <objectgroup id="6" name="key1">
   <properties>

--- a/game/entity/enemy.py
+++ b/game/entity/enemy.py
@@ -6,7 +6,7 @@ from constants import TILE_SIZE
 from utils import Direction, Vector, center_of_tile
 
 
-class pathcolors:
+class PathColors:
     pathcoloridx = 0
     pathcolorlist = [
         (97, 82, 103),
@@ -32,7 +32,7 @@ class Enemy(arcade.Sprite):
         self.position = locations["spawn"]
         self.waypoints = locations["waypoints"]
         self.create_full_path()
-        self.pathcolor = pathcolors.get_color()
+        self.pathcolor = PathColors.get_color()
         self.movecount = 2
         self.maxvision = 3
         self.update_direction()

--- a/game/utils.py
+++ b/game/utils.py
@@ -36,6 +36,13 @@ class Vector(NamedTuple):
     __rmul__ = __mul__
 
 
+class Direction:
+    NORTH = Vector(0, 1)
+    EAST = Vector(1, 0)
+    SOUTH = Vector(0, -1)
+    WEST = Vector(-1, 0)
+
+
 def center_of_tile(x: int, y: int) -> Vector:
     """
     Get the exact center of the tile that co-ords xy is contained in.


### PR DESCRIPTION
Changes:

* Enemies now have a direction they face which gets updated to face
their next path position after each move
* Enemies now move 2 instead of 1, which will make it easier to create
challenging levels
* Enemy movements are animated, so you can see each individual move and
turn with small timing breaks in between. These means after each player
move, there will be 4 rendered snapshots: enemy move 1, enemy turn 1,
enemy move 2, enemy turn 2
* You can see enemy's vision which is blocked by walls. Currently have
a stand-in circle for rendering this.
* Added some more guards to the test map to show off the new features

Issues:

* Need better rendering of guard vision. Perhaps shading of all
non-vision points? Can this be accomplished with a mask?
* Pressing a key during the enemy move and having it do nothing feels
unresponsive. Move should probably be queued and then take effect as
soon as enemy is done. Should we queue multiple moves? Nice to have
feature, so low priority.